### PR TITLE
escape backslash

### DIFF
--- a/manifests/yumgroup.pp
+++ b/manifests/yumgroup.pp
@@ -20,7 +20,7 @@ define system::yumgroup(
       present,installed: {
         exec { "Installing ${name} yum group":
           command  => "/usr/bin/yum -y groupinstall ${pkg_types_arg} '${name}'",
-          unless   => "/usr/bin/yum ${cache} grouplist 2>/dev/null | /usr/bin/perl -ne 'last if /^Available/o; next if /^\w/o; print' | /bin/grep -qw '${name}'", # lint:ignore:80chars
+          unless   => "/usr/bin/yum ${cache} grouplist 2>/dev/null | /usr/bin/perl -ne 'last if /^Available/o; next if /^\\w/o; print' | /bin/grep -qw '${name}'", # lint:ignore:80chars
           timeout  => 600,
           schedule => $schedule,
         }
@@ -28,7 +28,7 @@ define system::yumgroup(
       absent: {
         exec { "Removing ${name} yum group":
           command  => "/usr/bin/yum -y groupremove ${pkg_types_arg} '${name}'",
-          unless   => "/usr/bin/yum ${cache} grouplist 2>/dev/null | /usr/bin/perl -ne 'last if /^Available/o; next if /^\w/o; print' | /bin/grep -qw '${name}'", # lint:ignore:80chars
+          unless   => "/usr/bin/yum ${cache} grouplist 2>/dev/null | /usr/bin/perl -ne 'last if /^Available/o; next if /^\\w/o; print' | /bin/grep -qw '${name}'", # lint:ignore:80chars
           timeout  => 600,
           schedule => $schedule,
         }


### PR DESCRIPTION
need to escape the backslash to retain as/is within double-quotes and avoid warning in puppetserver.log
