### PR TITLE
properly escape backslash within double-quotes

### DIFF
--- a/manifests/sshd.pp
+++ b/manifests/sshd.pp
@@ -26,7 +26,7 @@ class system::sshd (
     # and https://wiki.xkyle.com/Managing_SSH_Keys_With_Puppet
 
     # export host key
-    $hostonly = regsubst($::fqdn, "\.${::domain}$", '')
+    $hostonly = regsubst($::fqdn, "\\.${::domain}$", '')
     $host_aliases = [ $::ipaddress, $hostonly ]
     @@sshkey { $::fqdn:
       ensure       => present,


### PR DESCRIPTION
```
Avoid warning such as: WARN  [puppet-server] Puppet Unrecognised escape sequence '\.' in file /etc/puppetlabs/puppet/environments/production/modules/system/manifests/sshd.pp
```
